### PR TITLE
Added HTTP header for identifying use of the proxy

### DIFF
--- a/customer-stack/customer-stack.yml
+++ b/customer-stack/customer-stack.yml
@@ -62,6 +62,10 @@ Parameters:
     Description: "Path within codeBucket where the lambda code is (example: libraries/create-resources-0.1.zip)"
     Default: "libraries/create-resources-0.1.zip"
     MinLength: 1
+Mappings:
+  Package:
+    Attributes:
+      Identifier: "'SagemakerProxy/0.1'"
 Conditions:
   KMSKeyArnProvided: !Not
     - !Equals
@@ -391,6 +395,7 @@ Resources:
         RequestParameters:
           integration.request.header.X-Amz-Target: "'SageMaker.CreateAutoMLJob'"
           integration.request.header.Content-Type: "'application/x-amz-json-1.1'"
+          integration.request.header.X-Proxy-Agent: !FindInMap [Package, Attributes, Identifier]
         PassthroughBehavior: WHEN_NO_MATCH
         IntegrationResponses:
           - StatusCode: 200
@@ -419,6 +424,7 @@ Resources:
           integration.request.path.endpointName: method.request.path.endpointName
           integration.request.header.Content-Type: "'text/csv'"
           integration.request.header.Accept: "'application/json'"
+          integration.request.header.X-Proxy-Agent: !FindInMap [Package, Attributes, Identifier]
         Credentials: !GetAtt SnowflakeAPIGatewayExecutionRole.Arn
         PassthroughBehavior: WHEN_NO_MATCH
         Uri:
@@ -463,7 +469,8 @@ Resources:
         RequestParameters:
           integration.request.header.X-Amz-Target: "'SageMaker.DeleteEndpoint'"
           integration.request.header.Content-Type: "'application/x-amz-json-1.1'"
-        PassthroughBehavior: WHEN_NO_MATCH        
+          integration.request.header.X-Proxy-Agent: !FindInMap [Package, Attributes, Identifier]
+        PassthroughBehavior: WHEN_NO_MATCH
         IntegrationResponses:
           - StatusCode: 200
             SelectionPattern: '2..'            
@@ -497,6 +504,7 @@ Resources:
         RequestParameters:
           integration.request.header.X-Amz-Target: "'SageMaker.CreateEndpoint'"
           integration.request.header.Content-Type: "'application/x-amz-json-1.1'"
+          integration.request.header.X-Proxy-Agent: !FindInMap [Package, Attributes, Identifier]
         PassthroughBehavior: WHEN_NO_MATCH
         IntegrationResponses:
           - StatusCode: 200
@@ -531,7 +539,8 @@ Resources:
         RequestParameters:
           integration.request.header.X-Amz-Target: "'SageMaker.DescribeAutoMLJob'"
           integration.request.header.Content-Type: "'application/x-amz-json-1.1'"
-        PassthroughBehavior: WHEN_NO_MATCH        
+          integration.request.header.X-Proxy-Agent: !FindInMap [Package, Attributes, Identifier]
+        PassthroughBehavior: WHEN_NO_MATCH
         IntegrationResponses:
           - StatusCode: 200
             SelectionPattern: '2..'            
@@ -565,7 +574,8 @@ Resources:
         RequestParameters:
           integration.request.header.X-Amz-Target: "'SageMaker.DescribeEndpoint'"
           integration.request.header.Content-Type: "'application/x-amz-json-1.1'"
-        PassthroughBehavior: WHEN_NO_MATCH        
+          integration.request.header.X-Proxy-Agent: !FindInMap [Package, Attributes, Identifier]
+        PassthroughBehavior: WHEN_NO_MATCH
         IntegrationResponses:
           - StatusCode: 200
             SelectionPattern: '2..'            
@@ -599,7 +609,8 @@ Resources:
         RequestParameters:
           integration.request.header.X-Amz-Target: "'SageMaker.DescribeEndpointConfig'"
           integration.request.header.Content-Type: "'application/x-amz-json-1.1'"
-        PassthroughBehavior: WHEN_NO_MATCH        
+          integration.request.header.X-Proxy-Agent: !FindInMap [Package, Attributes, Identifier]
+        PassthroughBehavior: WHEN_NO_MATCH
         IntegrationResponses:
           - StatusCode: 200
             SelectionPattern: '2..'            
@@ -633,7 +644,8 @@ Resources:
         RequestParameters:
           integration.request.header.X-Amz-Target: "'SageMaker.CreateEndpointConfig'"
           integration.request.header.Content-Type: "'application/x-amz-json-1.1'"
-        PassthroughBehavior: WHEN_NO_MATCH        
+          integration.request.header.X-Proxy-Agent: !FindInMap [Package, Attributes, Identifier]
+        PassthroughBehavior: WHEN_NO_MATCH
         IntegrationResponses:
           - StatusCode: 200
             SelectionPattern: '2..'
@@ -667,7 +679,8 @@ Resources:
         RequestParameters:
           integration.request.header.X-Amz-Target: "'SageMaker.DeleteEndpointConfig'"
           integration.request.header.Content-Type: "'application/x-amz-json-1.1'"
-        PassthroughBehavior: WHEN_NO_MATCH        
+          integration.request.header.X-Proxy-Agent: !FindInMap [Package, Attributes, Identifier]
+        PassthroughBehavior: WHEN_NO_MATCH
         IntegrationResponses:
           - StatusCode: 200
             SelectionPattern: '2..'            


### PR DESCRIPTION
### Notes
Added HTTP header for identifying use of the proxy

### Testing done
```
aws cloudformation create-stack \
--region us-east-2 \
--stack-name FullEndToEndTestFlintstoneSnowflakePR17 \
--template-body file://customer-stack/customer-stack.yml \
--capabilities CAPABILITY_NAMED_IAM \
--parameters ParameterKey=s3BucketName,ParameterValue=fulle2e-flintstone-snowflake-cmh-prod-pr17 \
ParameterKey=snowflakeRole,ParameterValue=ACCOUNTADMIN \
ParameterKey=snowflakeDatabaseName,ParameterValue=DEV_DB \
ParameterKey=snowflakeSchemaName,ParameterValue=PUBLIC \
ParameterKey=apiGatewayName,ParameterValue=fulle2e-flintstone-snowflake-cmh-prod-pr17 \
ParameterKey=snowflakeSecretArn,ParameterValue=arn:aws:secretsmanager:us-east-2:*******:secret:snowflake-user-cWlC3m \
ParameterKey=codeBucket,ParameterValue=fulle2e-snowflake-connector \
ParameterKey=pathToLayerCode,ParameterValue=snowflake-connector-python-1.0.zip \
ParameterKey=pathToLambdaCode,ParameterValue=create-resources.py.zip
```
```
select AWS_AUTOPILOT_DESCRIBE_MODEL('dummy');

Request failed for external function AWS_AUTOPILOT_DESCRIBE_MODEL with remote service error: 400 '{"__type":"ResourceNotFound","Message":"Amazon SageMaker can't find an AutoML job called dummy-job."}'; requests batch-id: 019e0657-0000-419b-0000-8d29000da49a:0:0; request batch size: 1 rows; request retries: 0; response time (last retry): 140.03ms
```