### PR TITLE
Various Fixes

### DIFF
--- a/customer-stack/create-resources.py
+++ b/customer-stack/create-resources.py
@@ -432,7 +432,7 @@ def create_describeendpoint_ef(snowflake_cursor, api_integration_name, api_gatew
     describeendpoint_deserializer_str = ("create or replace function AWS_AUTOPILOT_DESCRIBE_ENDPOINT_DESERIALIZER(EVENT OBJECT) \
         returns OBJECT LANGUAGE JAVASCRIPT AS \
         $$ \
-            return {\"body\": {   \"data\" : [[0, EVENT.body]]  }}\
+            return {\"body\": {   \"data\" : [[0, EVENT.body]]  }}  \
         $$;")
 
     snowflake_cursor.execute(describeendpoint_deserializer_str)
@@ -488,7 +488,7 @@ def create_predictoutcome_ef(snowflake_cursor, api_integration_name, api_gateway
     predictoutcome_serializer_str = ("create or replace function AWS_AUTOPILOT_PREDICT_OUTCOME_SERIALIZER(EVENT OBJECT) \
         returns OBJECT LANGUAGE JAVASCRIPT AS \
         $$ \
-        let modelName = \"/\"  + EVENT.body.data[0][1]; \
+        let modelName = \"/\"  + EVENT.body.data[0][1]; /* TODO: we should rename this variable endpointName */ \
         var payload = []; \
         for(i = 0; i < EVENT.body.data.length; i++) { \
             var row = EVENT.body.data[i]; \


### PR DESCRIPTION
### Notes
Various fixed from End to End testing

### Testing done
```
select AWS_AUTOPILOT_CREATE_MODEL('model-20210604-1','ABALONE', 'RINGS');
```
-> Failed on vpc related arguments being incorrectly checked

```
select AWS_AUTOPILOT_DESCRIBE_MODEL('model-20210604-2');

// JavaScript execution error: Uncaught TypeError: Cannot read property 'FinalAutoMLJobObjectiveMetric' of undefined in AWS_AUTOPILOT_DESCRIBE_MODEL_DESERIALIZER at ' let responseBody = EVENT.body; let response ={}; response["JobStatus"] = responseBody.AutoMLJobStatus; response["JobStatusDetails"] = responseBody.AutoMLJobSecondaryStatus; if (responseBody.AutoMLJobStatus === "Completed") { response["ObjectiveMetric"] = responseBody.BestCandidate.FinalAutoMLJobObjectiveMetric.MetricName; response["BestObjectiveMetric"] = responseBody.BestCandidate.FinalAutoMLJobObjectiveMetric.Value; } else if (responseBody.AutoMLJobStatus === "Failed") { response["FailureReason"] = responseBody.FailureReason; } response["PartialFailureReasons"] = responseBody.PartialFailureReasons; response["AutoMLJobSecondaryStatus"] = responseBody.AutoMLJobSecondaryStatus; return {"body":{ "data" : [[0,response]] }}; ' position 340 stackstrace: AWS_AUTOPILOT_DESCRIBE_MODEL_DESERIALIZER line: 2 AWS_AUTOPILOT_DESCRIBE_MODEL_DESERIALIZER line: 3
```
-> Failed on incorrect assumption of FinalAutoMLJobObjectiveMetric be present for all Completed jobs (which is not true for "Completed" +  "AutoMLJobSecondaryStatus": "MaxAutoMLJobRuntimeReached"