### PR TITLE
Adding package version as argument to SnowflakeResources. 

### DIFF
--- a/customer-stack/customer-stack.yml
+++ b/customer-stack/customer-stack.yml
@@ -838,3 +838,4 @@ Resources:
       ServiceToken: !Sub
         - "${lambdaArn}"
         - lambdaArn: !GetAtt CreateSnowflakeResourcesLambda.Arn
+      PackageIdentifier: !FindInMap [Package, Attributes, Identifier]


### PR DESCRIPTION
### Notes
Re-execution of CreateSnowflakeResourcesLambda can now be triggered by bumping the version.

### Testing done

Manually using Cloudformation UI.
Updating the stack with modified CFT now triggers re-execution of SnowflakeResources custom resource.

Bumping of the version simulated using following update locally:
```
Mappings:
  Package:
    Attributes:
      Identifier: "'SagemakerProxy/0.2'"
```