### PR TITLE
Enabling batches of 100 records for PREDICT_OUTCOME. 

### DIFF
--- a/customer-stack/create-resources.py
+++ b/customer-stack/create-resources.py
@@ -519,7 +519,7 @@ def create_predictoutcome_ef(snowflake_cursor, api_integration_name, api_gateway
     api_integration = \"%s\" \
     serializer = AWS_AUTOPILOT_PREDICT_OUTCOME_SERIALIZER \
     deserializer=AWS_AUTOPILOT_PREDICT_OUTCOME_DESERIALIZER \
-    max_batch_rows=1 \
+    max_batch_rows=100 \
     as '%s/predictoutcome';") % (api_integration_name, api_gateway_url)
 
     snowflake_cursor.execute(create_predictoutcome_ef_str)


### PR DESCRIPTION
### Notes
Enabling batches of 100 records for PREDICT_OUTCOME. 
Speeds up prediction by 100x.

### Testing done
Before this change:
```
select AWS_AUTOPILOT_PREDICT_OUTCOME('model-20210605-1', array_construct(sex, length, diameter, height, whole_weight, shucked_weight, viscera_weight, shell_weight)) as prediction 
from ABALONE_TEST LIMIT 100000;
-- 10m30s 100,000 rows
```

After this change:
```
select AWS_AUTOPILOT_PREDICT_OUTCOME('model-20210605-1', array_construct(sex, length, diameter, height, whole_weight, shucked_weight, viscera_weight, shell_weight)) as prediction 
from ABALONE_TEST LIMIT 100000;
-- 6.86s 100,0000 rows
```

Note: Batches of 100 should be a good middle ground also for data sets with number of columns > 1000. However the size of one request can then go as high as 1 MB which should still be acceptable (100 rows x 1000 columns x 10B per cell).
